### PR TITLE
Fix reëntrant events/spans escaping per-layer filters (round 2)

### DIFF
--- a/tracing-subscriber/src/filter/layer_filters/mod.rs
+++ b/tracing-subscriber/src/filter/layer_filters/mod.rs
@@ -1120,11 +1120,6 @@ impl FilterMap {
     pub(crate) fn any_enabled(self) -> bool {
         self.disabled != std::u64::MAX
     }
-
-    #[inline]
-    pub(crate) fn any_seen(self) -> bool {
-        self.seen != 0
-    }
 }
 
 impl fmt::Debug for FilterMap {

--- a/tracing-subscriber/src/filter/layer_filters/mod.rs
+++ b/tracing-subscriber/src/filter/layer_filters/mod.rs
@@ -726,6 +726,39 @@ where
     fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
         let interest = self.filter.callsite_enabled(metadata);
 
+        // Per-layer filters use thread-local state to store whether they've
+        // disabled a given event/span from the `enabled()` call until the
+        // `event()`/`new_span()` call.
+        //
+        // Unfortunately, if we allow a per-layer filter to express an "always"
+        // interest in a callsite, and an event is emitted from that callsite
+        // *from within a re-entrant call* (e.g. the calculation of the value of
+        // an event's field itself causes an event to be emitted), there are
+        // situations where `enabled()` will not be called for the inner event.
+        // There is no straightforward way, in that situation, to keep the inner
+        // event from both:
+        //
+        // - Exhibiting incorrect behaviour due to misinterpretation of the
+        //   thread-local state (usually, not emitting the inner event even
+        //   though it should have been enabled)
+        // - Clobbering the thread-local state of the outer event (usually,
+        //   ending up emitting the outer event even though it should have been
+        //   disabled)
+        //
+        // The solution for the time being is therefore that we have to consider
+        // per-layer filters too broken to allow them to express an "always"
+        // interest, and we have to knock this down to "sometimes". The
+        // `enabled()` function will therefore always be called on events/spans
+        // that are subject to a per-layer filter; while the performance
+        // regression is regrettable, this will ensure that per-layer filters
+        // are always given the chance to push and pop their filter state to its
+        // stack, so they can correctly handle re-entrant calls.
+        let interest = if interest.is_always() {
+            Interest::sometimes()
+        } else {
+            interest
+        };
+
         // If the filter didn't disable the callsite, allow the inner layer to
         // register it — since `register_callsite` is also used for purposes
         // such as reserving/caching per-callsite data, we want the inner layer

--- a/tracing-subscriber/src/layer/layered.rs
+++ b/tracing-subscriber/src/layer/layered.rs
@@ -433,7 +433,41 @@ where
 
     fn pick_interest(&self, outer: Interest, inner: impl FnOnce() -> Interest) -> Interest {
         if self.has_layer_filter {
-            return inner();
+            let inner = inner();
+
+            // Per-layer filters use thread-local state to store whether they've
+            // disabled a given event/span from the `enabled()` call until the
+            // `event()`/`new_span()` call.
+            //
+            // Unfortunately, if we allow a per-layer filter to express an
+            // "always" interest in a callsite, and an event is emitted from
+            // that callsite *from within a re-entrant call* (e.g. the
+            // calculation of the value of an event's field itself causes an
+            // event to be emitted), there are situations where `enabled()` will
+            // not be called for the inner event. There is no straightforward
+            // way, in that situation, to keep the inner event from both:
+            //
+            // - Exhibiting incorrect behaviour due to misinterpretation of the
+            //   thread-local state (usually, not emitting the inner event even
+            //   though it should have been enabled)
+            // - Clobbering the thread-local state of the outer event (usually,
+            //   ending up emitting the outer event even though it should have
+            //   been disabled)
+            //
+            // The solution for the time being is therefore that we have to
+            // consider per-layer filters too broken to allow them to express an
+            // "always" interest, and we have to knock this down to "sometimes".
+            // The `enabled()` function will therefore always be called on
+            // events/spans that are subject to a per-layer filter; while the
+            // performance regression is regrettable, this will ensure that
+            // per-layer filters are always given the chance to push and pop
+            // their filter state to its stack, so they can correctly handle
+            // re-entrant calls.
+            if inner.is_always() {
+                return Interest::sometimes();
+            }
+
+            return inner;
         }
 
         // If the outer layer has disabled the callsite, return now so that

--- a/tracing-subscriber/tests/layer_filter_interests_are_cached.rs
+++ b/tracing-subscriber/tests/layer_filter_interests_are_cached.rs
@@ -8,6 +8,7 @@ use tracing_mock::{expect, layer};
 use tracing_subscriber::{filter, prelude::*};
 
 #[test]
+#[ignore = "fails due to an intentional, necessary, performance regression from the layer filter re-entrancy fix"]
 fn layer_filter_interests_are_cached() {
     let seen = Arc::new(Mutex::new(HashMap::new()));
     let seen2 = seen.clone();

--- a/tracing-subscriber/tests/layer_filters/main.rs
+++ b/tracing-subscriber/tests/layer_filters/main.rs
@@ -4,6 +4,7 @@ mod downcast_raw;
 mod filter_scopes;
 mod option;
 mod per_event;
+mod reentrancy;
 mod targets;
 mod trees;
 mod vec;

--- a/tracing-subscriber/tests/layer_filters/reentrancy.rs
+++ b/tracing-subscriber/tests/layer_filters/reentrancy.rs
@@ -1,0 +1,220 @@
+//! Tests to ensure events cannot escape through per-layer filters as the result
+//! of re-entrant event or span construction. These are regression tests for the
+//! following issues:
+//!
+//! - <https://github.com/tokio-rs/tracing/issues/2704>
+//! - <https://github.com/tokio-rs/tracing/issues/2448>
+//!
+//! Per-layer filters use thread-local state to record whether they enabled an
+//! event or span, and then read that state later to determine whether they
+//! should process said event or span. Since the sequence of events that the
+//! `event!()` macro performs is roughly as follows...
+//!
+//! 1. Construct the metadata of the event and let the subscriber determine
+//!    whether it will be globally disabled (at which point per-layer filters
+//!    set their thread-local enablement state)
+//! 2. If the event is not globally disabled, construct the event, including the
+//!    values of all its fields
+//! 3. Pass the event to the subscriber (at which point per-layer filters read
+//!    their thread-local enablement state)
+//!
+//! ...then if, in the process of constructing the event, any *other* spans or
+//! events are created, they had the potential to cause the per-layer filters to
+//! clobber their thread-local state from the outer event. By the time step 3 is
+//! reached, they would believe they had not disabled the outer event,
+//! regardless of whether they actually had.
+//!
+//! This could actually happen in two different ways, the upshot of which is
+//! that it doesn't actually matter if the re-entrant event/span would have been
+//! enabled by the filter or not; it *still* would cause the outer one to escape
+//! the filter. There are tests for both cases.
+
+use super::*;
+
+/// Test that a disabled span, created inside the fields or message of an event,
+/// does not cause the outer event to escape a per-layer filter that would
+/// otherwise have disabled it.
+///
+/// This particular test uses a nested span that, like the outer message, should
+/// *not* pass the filter (it's at TRACE level, while the filter is at ERROR).
+/// This causes the filter to correctly determine that the span is disabled, but
+/// when the span is processed, the filter clears its bit in the filter state.
+/// The information that the outer event was disabled is therefore clobbered,
+/// and it gets through the filter.
+#[test]
+fn disabled_span_inside_event() {
+    let (expect, handle) = layer::named("plf_error").only().run_with_handle();
+
+    let _subscriber = tracing_subscriber::registry()
+        .with(expect.with_filter(LevelFilter::ERROR))
+        .with(LevelFilter::TRACE)
+        .set_default();
+
+    // Regardless of anything else, the layer should *not* receive this event.
+    // If this one gets through, something else is wrong!
+    tracing::trace!("plain event");
+
+    #[tracing::instrument(level = "trace")]
+    fn instrumented() -> &'static str {
+        "foo"
+    }
+
+    // These events demonstrate the filter escape behaviour. `instrumented()` is
+    // run between the enablement determination of the event and its actual
+    // processing, causing buggy per-layer filters to clobber their own filter
+    // state.
+    tracing::trace!("formatted into the message: {}", instrumented());
+    tracing::trace!(bar = %instrumented(), "as the value of a field");
+
+    handle.assert_finished();
+}
+
+/// Test that an enabled span, created inside the fields or message of an event,
+/// does not cause the outer event to escape a per-layer filter that would
+/// otherwise have disabled it.
+///
+/// This test uses a nested span that *should* pass the filter (it's at ERROR
+/// level, the only level the filter lets through). This directly clobbers the
+/// enablement information of the outer event, since when the per-layer filter
+/// first sees the span metadata, it sets its filter state to enabled,
+/// overwriting the disabled state that it recorded for the outer event.
+#[test]
+fn enabled_span_inside_event() {
+    let (expect, handle) = layer::named("plf_error")
+        .new_span(expect::span().at_level(Level::ERROR))
+        .new_span(expect::span().at_level(Level::ERROR))
+        .only()
+        .run_with_handle();
+
+    let _subscriber = tracing_subscriber::registry()
+        .with(expect.with_filter(LevelFilter::ERROR))
+        .with(LevelFilter::TRACE)
+        .set_default();
+
+    // Regardless of anything else, the layer should *not* receive this event.
+    // If this one gets through, something else is wrong!
+    tracing::trace!("plain event");
+
+    #[tracing::instrument(level = "error")]
+    fn instrumented() -> &'static str {
+        "foo"
+    }
+
+    // These events demonstrate the filter escape behaviour. `instrumented()` is
+    // run between the enablement determination of the event and its actual
+    // processing, causing buggy per-layer filters to clobber their own filter
+    // state.
+    tracing::trace!("formatted into the message: {}", instrumented());
+    tracing::trace!(bar = %instrumented(), "as the value of a field");
+
+    handle.assert_finished();
+}
+
+/// This is exactly like [`disabled_span_inside_event()`], but it uses an
+/// *event* nested inside an event. The mechanism of the bug is exactly the
+/// same.
+#[test]
+fn disabled_event_inside_event() {
+    let (expect, handle) = layer::named("error").only().run_with_handle();
+
+    let _subscriber = tracing_subscriber::registry()
+        .with(expect.with_filter(LevelFilter::ERROR))
+        .with(LevelFilter::TRACE)
+        .set_default();
+
+    // Regardless of anything else, the layer should *not* receive this event.
+    // If this one gets through, something else is wrong!
+    tracing::trace!("plain event");
+
+    fn nested_event() -> &'static str {
+        tracing::trace!("this is a nested event");
+        "foo"
+    }
+
+    // These events demonstrate the filter escape behaviour. `instrumented()` is
+    // run between the enablement determination of the event and its actual
+    // processing, causing buggy per-layer filters to clobber their own filter
+    // state.
+    tracing::trace!("formatted into the message: {}", nested_event());
+    tracing::trace!(bar = %nested_event(), "as the value of a field");
+
+    handle.assert_finished();
+}
+
+/// This is exactly like [`enabled_span_inside_event()`], but it uses an *event*
+/// nested inside an event. The mechanism of the bug is exactly the same.
+#[test]
+fn enabled_event_inside_event() {
+    let (expect, handle) = layer::named("error")
+        .event(expect::event().at_level(Level::ERROR))
+        .event(expect::event().at_level(Level::ERROR))
+        .only()
+        .run_with_handle();
+
+    let _subscriber = tracing_subscriber::registry()
+        .with(expect.with_filter(LevelFilter::ERROR))
+        .with(LevelFilter::TRACE)
+        .set_default();
+
+    // Regardless of anything else, the layer should *not* receive this event.
+    // If this one gets through, something else is wrong!
+    tracing::trace!("plain event");
+
+    fn nested_event() -> &'static str {
+        tracing::error!("this is a nested event");
+        "foo"
+    }
+
+    // These events demonstrate the filter escape behaviour. `instrumented()` is
+    // run between the enablement determination of the event and its actual
+    // processing, causing buggy per-layer filters to clobber their own filter
+    // state.
+    tracing::trace!("formatted into the message: {}", nested_event());
+    tracing::trace!(bar = %nested_event(), "as the value of a field");
+
+    handle.assert_finished();
+}
+
+/// Just a test for good measure, that this can also be caused by a nested event
+/// that appears directly inline in the event macro.
+#[test]
+fn inline_event_in_event_macro() {
+    let (expect, handle) = layer::named("error").only().run_with_handle();
+
+    let _subscriber = tracing_subscriber::registry()
+        .with(expect.with_filter(LevelFilter::ERROR))
+        .with(LevelFilter::TRACE)
+        .set_default();
+
+    tracing::trace!("in the message: {:?}", tracing::trace!("inline event"));
+    tracing::trace!(bar = ?tracing::trace!("inline event"), "in a field");
+
+    handle.assert_finished();
+}
+
+/// This is again similar to the above tests, but ensures that the *fix* for the
+/// bug doesn't rely on keying per-layer filter enablement status by callsite
+/// identifier. Otherwise, this event would still escape, because the inner
+/// (re-entrant) event comes from exactly the same callsite.
+#[test]
+fn recursive_events() {
+    let (expect, handle) = layer::named("error").only().run_with_handle();
+
+    let _subscriber = tracing_subscriber::registry()
+        .with(expect.with_filter(LevelFilter::ERROR))
+        .with(LevelFilter::TRACE)
+        .set_default();
+
+    fn recurse(n: usize) -> usize {
+        if n == 0 {
+            return 0;
+        }
+
+        tracing::trace!(result = %recurse(n - 1), "recursing");
+        n
+    }
+
+    recurse(2);
+
+    handle.assert_finished();
+}

--- a/tracing-subscriber/tests/layer_filters/reentrancy.rs
+++ b/tracing-subscriber/tests/layer_filters/reentrancy.rs
@@ -82,7 +82,11 @@ fn disabled_span_inside_event() {
 fn enabled_span_inside_event() {
     let (expect, handle) = layer::named("plf_error")
         .new_span(expect::span().at_level(Level::ERROR))
+        .enter(expect::span().at_level(Level::ERROR))
+        .exit(expect::span().at_level(Level::ERROR))
         .new_span(expect::span().at_level(Level::ERROR))
+        .enter(expect::span().at_level(Level::ERROR))
+        .exit(expect::span().at_level(Level::ERROR))
         .only()
         .run_with_handle();
 

--- a/tracing-subscriber/tests/multiple_layer_filter_interests_cached.rs
+++ b/tracing-subscriber/tests/multiple_layer_filter_interests_cached.rs
@@ -8,6 +8,7 @@ use tracing_mock::{expect, layer};
 use tracing_subscriber::{filter, prelude::*};
 
 #[test]
+#[ignore = "fails due to an intentional, necessary, performance regression from the layer filter re-entrancy fix"]
 fn multiple_layer_filter_interests_are_cached() {
     // This layer will return Interest::always for INFO and lower.
     let seen_info = Arc::new(Mutex::new(HashMap::new()));

--- a/tracing-subscriber/tests/option_filter_interest_caching.rs
+++ b/tracing-subscriber/tests/option_filter_interest_caching.rs
@@ -11,6 +11,7 @@ use tracing_subscriber::{filter, prelude::*, Layer};
 /// A `None` filter should always be interested in events, and it should not
 /// needlessly degrade the caching of other filters.
 #[test]
+#[ignore = "fails due to an intentional, necessary, performance regression from the layer filter re-entrancy fix"]
 fn none_interest_cache() {
     let (layer_none, handle_none) = layer::mock()
         .event(expect::event())

--- a/tracing-subscriber/tests/vec_subscriber_filter_interests_cached.rs
+++ b/tracing-subscriber/tests/vec_subscriber_filter_interests_cached.rs
@@ -8,6 +8,7 @@ use tracing_mock::{layer::MockLayer, *};
 use tracing_subscriber::{filter, prelude::*};
 
 #[test]
+#[ignore = "fails due to an intentional, necessary, performance regression from the layer filter re-entrancy fix"]
 fn vec_layer_filter_interests_are_cached() {
     let mk_filtered = |level: Level, subscriber: MockLayer| {
         let seen = Arc::new(Mutex::new(HashMap::new()));


### PR DESCRIPTION
Replaces #1, still a fork-internal PR. Still motivated by getditto/ditto#13306, still see tokio-rs/tracing#2704 for context & discussion.

This fix includes two major changes, the second of which was also in #1:

- When a per-layer filter is asked to check whether it enabled or disabled an event/span, it clears a bit in the filter state to indicate that it has done so. The next time that function (`did_enable()`) is called, it will check that bit, see that the filter state has been cleared, and _recalculate_ the enablement status based on the current event/span's metadata. In that way, the filter state is now treated as a _cache_, which is invalidated when we would have read from stale state. Reëntrant events can therefore no longer clobber the filter state.
- `Filtered` layers, which are layers that have a per-layer filter attached, no longer ever store their interest as "always", instead knocking down an "always" interest to "sometimes". This likely represents a performance regression, but it's a necessary one in order to force the reëvaluation of `enabled()` for every span/event - if we use "always" and short-circuit that call, we see incorrect behavior for some kinds of reëntrant event scenarios (such as the new test `enabled_event_inside_event`)